### PR TITLE
Fix WPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "squizlabs/php_codesniffer": "3.*",
     "dealerdirect/phpcodesniffer-composer-installer": "*",
     "object-calisthenics/phpcs-calisthenics-rules": "*",
-    "wp-coding-standards/wpcs": "*"
+    "wp-coding-standards/wpcs": "~2.1.0"
   },
   "autoload": {
     "psr-0": {

--- a/src/Tailwind/Standard/Tailwind/ruleset.xml
+++ b/src/Tailwind/Standard/Tailwind/ruleset.xml
@@ -6,7 +6,7 @@
     </description>
 
     <!--We use some WordPress rules, so we autoload those in-->
-    <autoload>./vendor/wp-coding-standards/wpcs/WordPress/PHPCSAliases.php</autoload>
+    <autoload>./vendor/wp-coding-standards/wpcs/WordPress/PHPCSHelper.php</autoload>
 
     <!-- ========================= -->
     <!-- ======== Arrays ========= -->


### PR DESCRIPTION
# What?
This PR specifies a version of `wpcs` and loads the new autoload file.

# Why?
Since `wpcs` didn't have a specified version, a breaking change was introduced where `PHPCSAliases.php` was renamed to `PHPCSHelper.php`